### PR TITLE
Add template cloning support

### DIFF
--- a/cut-list.php
+++ b/cut-list.php
@@ -195,6 +195,9 @@
                                     <a :href="'template-form.php?id=' + template.id" class="button is-small info-button mr-2" title="Edit Template">
                                         <span class="icon is-small"><i class="fas fa-edit"></i></span>
                                     </a>
+                                    <a :href="'template-form.php?cloneFrom=' + template.id" class="button is-small info-button mr-2" title="Clone Template">
+                                        <span class="icon is-small"><i class="fas fa-clone"></i></span>
+                                    </a>
                                     <button class="button is-small danger-button card-header-icon" @click="removeTemplate(template.id)" title="Delete Template">
                                         <span class="icon is-small"><i class="fas fa-trash"></i></span>
                                     </button>
@@ -606,6 +609,18 @@ async loadAllTemplates() {
                 if (template) {
                     template.partDefinitions = template.partDefinitions.filter(pd => pd.id !== partDefIdToRemove);
                 }
+            },
+            cloneTemplate(templateIdToClone) {
+                const original = this.partDefinitionTemplates.find(t => t.id === templateIdToClone);
+                if (!original) return;
+                const cloned = JSON.parse(JSON.stringify(original));
+                cloned.id = this._getNewTemplateId();
+                cloned.name = `${original.name} (Clone)`;
+                cloned.partDefinitions = cloned.partDefinitions.map(pd => ({
+                    ...pd,
+                    id: this._getNewTemplatePartDefId()
+                }));
+                this.partDefinitionTemplates.push(cloned);
             },
 
             // --- KEBENET Group Management Methods ---

--- a/template-form.php
+++ b/template-form.php
@@ -138,10 +138,17 @@
                 init() {
                     const urlParams = new URLSearchParams(window.location.search);
                     const templateId = urlParams.get('id');
+                    const cloneFrom = urlParams.get('cloneFrom');
 
                     if (templateId) {
                         this.mode = 'edit';
                         this.loadTemplate(templateId);
+                    } else if (cloneFrom) {
+                        this.mode = 'add';
+                        this.loadTemplate(cloneFrom).then(() => {
+                            this.template.id = null;
+                            this.template.name = `${this.template.name} (Clone)`;
+                        });
                     } else {
                         this.mode = 'add';
                         


### PR DESCRIPTION
## Summary
- enable cloning templates from URL param
- add "Clone Template" link in template list
- implement optional `cloneTemplate` helper

## Testing
- `php -l template-form.php` *(fails: command not found)*
- `php -l cut-list.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518c2a86848329b93f76a3396bacad